### PR TITLE
Corrected company name Ervy to EVRY

### DIFF
--- a/order-nsp.md
+++ b/order-nsp.md
@@ -59,7 +59,7 @@ The table gives details about the IBM Cloud datacenters where Direct Link Dedica
 | LON04 | ARK | A103 | A57 Cody Technology Park Old, Victor Way, Farnborough |
 | LON06 | Zenium | LON1 | 12 Liverpool Rd, Trading Estate |
 | MIL02 | Infracom Italia | Infracom 21 Via Caldera Way | Infracom Italia Spa, Building D, Caldera Business Park, Via Caldera, 21|
-| OSL01 | Ervy | DigiPlex - Fetsund | 9,, Heiaveien, 1900 Fetsund |
+| OSL01 | EVRY | DigiPlex - Fetsund | 9,, Heiaveien, 1900 Fetsund |
 | OSL02 | Verizon | Verizon Oslo | Hans Møller Gassmanssvei 9 |
 | PAR01 | IBM | PAR01 | Société par Actions Simplifiée Unipersonnelle, 7-9 rue Petit |
 | PAR02 | Equinix | PA2 | 114 Rue Ambroise Croizat, St Denis |


### PR DESCRIPTION
Corrected a typo in the company name of the partner at OSL01. Can be verified at https://www.evry.com/.